### PR TITLE
Update to z3-sys 0.5.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,14 +8,14 @@ name = "rust_smt"
 version = "0.2.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "z3-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "z3-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "z3-sys"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum z3-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1dff903712349c6fa80acbd690641acd98f170a2e01b6f28f8fdcf850e2d4500"
+"checksum z3-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae57b4c31eabc2620fbf2ea3e4deac2cd8a12522ccc0ebcc29e60dff8137de31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 lazy_static = "1"
-z3-sys = "0.4.0"
+z3-sys = "0.5.0"


### PR DESCRIPTION
This updates to the new 0.5.0 release of `z3-sys` that I just made. I've got a CLA on file. This builds and the tests still pass.